### PR TITLE
ci: Vercel CLI 최신화 및 Node 20 마이그레이션

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,67 +9,63 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@v5
+
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
-          
+
       - name: Install dependencies
         run: |
           cd frontend
           npm ci
-      
+
       - name: Build project
         run: |
           cd frontend
           npm run build
         env:
           VITE_API_URL: ${{ secrets.VITE_API_URL }}
-      
+
       - name: Run tests (if any)
         run: |
           cd frontend
           echo "Tests would run here"
-  
+
   deploy:
     needs: build-and-test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    
+
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@v5
+
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '18'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-          
-      - name: Install dependencies
-        run: |
-          cd frontend
-          npm ci
-      
-      - name: Build project
-        run: |
-          cd frontend
-          npm run build
+          node-version: '20'
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel environment information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build project artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VITE_API_URL: ${{ secrets.VITE_API_URL }}
-          
+
       - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v25
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          vercel-args: '--prod'
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## 배경
GitHub Actions 배포 잡이 두 가지 이유로 실패/경고 발생:
1. `amondnet/vercel-action@v25`가 번들한 Vercel CLI가 구버전 → `This endpoint requires version 47.2.2 or later` 에러
2. `actions/checkout@v4`, `actions/setup-node@v4`의 Node.js 20 deprecation 경고

## 변경
- 배포를 공식 Vercel CLI 흐름으로 교체: `vercel pull` → `vercel build --prod` → `vercel deploy --prebuilt --prod` (`vercel@latest` 설치로 항상 최신 CLI)
- `actions/checkout`·`actions/setup-node` v4 → v5
- Node 18 → 20 (Node 18 EOL)

## 참고
`vercel.json`이 buildCommand/outputDirectory/routes를 self-contained로 정의하고 있어 기존 배포 설정 그대로 동작.